### PR TITLE
Remove torchaudio & torchvision deps

### DIFF
--- a/env/build_uv_env.sh
+++ b/env/build_uv_env.sh
@@ -147,7 +147,7 @@ echo "      Python: $(which python)"
 # 3. Install PyTorch with CUDA 12.6
 # ------------------------------------------------------------------------------
 echo "[3/7] Installing PyTorch 2.7.0 with CUDA 12.6..."
-uv pip install torch==2.7.0+cu126 torchvision torchaudio \
+uv pip install torch==2.7.0+cu126 \
     --index-url https://download.pytorch.org/whl/cu126
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
### Summary

Removes torchvision and torchaudio from the PyTorch install step in env/build_uv_env.sh. Neither package is used anywhere in the repo, and their presence was causing an import-time crash.

Fixes #42 

### Problem

Fresh environments crashed on import with a torchaudio/torch version mismatch. The install line pinned torch==2.7.0+cu126 but left torchvision and torchaudio unpinned, so the resolver pulled the latest builds — compiled against a different torch version, producing an ABI mismatch.

### Fix

```bash
-uv pip install torch==2.7.0+cu126 torchvision torchaudio \
+uv pip install torch==2.7.0+cu126 \
     --index-url https://download.pytorch.org/whl/cu126
```