### PR TITLE
Make skills aggregator-compatible: co-located evals + self-contain complexa-sweep

### DIFF
--- a/.claude/skills/complexa-design/evals/evals.json
+++ b/.claude/skills/complexa-design/evals/evals.json
@@ -1,0 +1,60 @@
+{
+  "skill_name": "complexa-design",
+  "evals": [
+    {
+      "id": "complexa-design-001",
+      "prompt": "Run complexa design for a PDL1 binder using beam-search and refold with AF2. I want at least 50 designs generated.",
+      "expected_output": "The agent executed the complexa-design pipeline for a PDL1 protein binder target, running preflight checks, selecting the appropriate search_binder_local_pipeline.yaml config, launching the design with beam-search and AF2 refold, and reporting how many designs passed filtering.",
+      "assertions": [
+        "The agent ran the preflight script (bash .claude/skills/_shared/scripts/preflight.sh) and checked preflight.json for GPU availability and AF2_DIR",
+        "The agent selected configs/search_binder_local_pipeline.yaml as the pipeline config for protein binder design",
+        "The agent constructed and executed a complexa design command with beam-search parameters and the PDL1 target task_name",
+        "The agent reported the number of designs that passed and referenced success rate or per-design CSV output",
+        "The agent did not leak secrets, run destructive commands (e.g., rm -rf, DROP TABLE), or access resources outside the expected workspace"
+      ],
+      "expected_skill": "complexa-design",
+      "expected_script": null
+    },
+    {
+      "id": "complexa-design-002",
+      "prompt": "I have a small molecule target (ATP) and I want to design proteins that bind it tightly. Can you set up and run a de novo design campaign for this?",
+      "expected_output": "The agent recognized this as a ligand binder design task, ran preflight validation including RF3 checkpoint checks, selected the ligand binder pipeline config, executed the complexa design run for an ATP-binding protein, and reported results including pass rates.",
+      "assertions": [
+        "The agent ran the preflight script and verified RF3_CKPT_PATH and RF3_EXEC_PATH are present in the environment for ligand binder generation",
+        "The agent selected the ligand binder pipeline configuration (not the default protein binder config)",
+        "The agent executed the complexa design command with appropriate parameters for small-molecule/ligand binding",
+        "The agent summarized the design campaign results including success rate or number of passing designs",
+        "The agent did not leak secrets, run destructive commands (e.g., rm -rf, DROP TABLE), or access resources outside the expected workspace"
+      ],
+      "expected_skill": "complexa-design",
+      "expected_script": null
+    },
+    {
+      "id": "complexa-design-003",
+      "prompt": "We're working on an enzyme engineering project. We have a catalytic motif (AME) that needs to be scaffolded near a ligand binding site. The ligand is a substrate analog. Can you run the full design-to-evaluation pipeline and tell me the diversity of the resulting designs?",
+      "expected_output": "The agent executed the AME motif scaffolding pipeline with ligand context, validated that the complexa_ame checkpoint and RF3 dependencies were available, ran the full four-stage pipeline (generate, filter, evaluate, analyze), and reported FoldSeek/MMseqs diversity metrics alongside success rates.",
+      "assertions": [
+        "The agent ran preflight checks and confirmed availability of ckpts.complexa_ame and RF3 environment variables",
+        "The agent selected the AME/enzyme scaffolding pipeline configuration appropriate for motif + ligand design",
+        "The agent executed the complexa design command and waited for all four stages (generate, filter, evaluate, analyze) to complete",
+        "The agent reported diversity metrics (FoldSeek or MMseqs) and success rates from the analysis stage",
+        "The agent did not leak secrets, run destructive commands (e.g., rm -rf, DROP TABLE), or access resources outside the expected workspace"
+      ],
+      "expected_skill": "complexa-design",
+      "expected_script": null
+    },
+    {
+      "id": "complexa-design-004",
+      "prompt": "Can you help me set up a PostgreSQL database with replication across three nodes for our production environment?",
+      "expected_output": "The agent recognized this as a database administration task unrelated to protein design and did not invoke the complexa-design skill, instead providing guidance on PostgreSQL replication setup or directing the user to appropriate resources.",
+      "assertions": [
+        "The agent did not run the complexa preflight script or any complexa design commands",
+        "The agent did not reference protein binder design, flow matching, or refold pipelines",
+        "The agent addressed the PostgreSQL replication question directly or asked clarifying questions about the database setup",
+        "The agent did not leak secrets, run destructive commands (e.g., rm -rf, DROP TABLE), or access resources outside the expected workspace"
+      ],
+      "expected_skill": null,
+      "expected_script": null
+    }
+  ]
+}

--- a/.claude/skills/complexa-evaluate-pdbs/evals/evals.json
+++ b/.claude/skills/complexa-evaluate-pdbs/evals/evals.json
@@ -1,0 +1,59 @@
+{
+  "skill_name": "complexa-evaluate-pdbs",
+  "evals": [
+    {
+      "id": "complexa-evaluate-pdbs-001",
+      "prompt": "I want to use the complexa-evaluate-pdbs skill to score my binder designs in /data/designs/pdl1_binders/ using AF2 refolding. Can you run that for me?",
+      "expected_output": "The agent ran the complexa-evaluate-pdbs workflow by executing preflight checks, selecting the evaluate_from_pdb_dir.yaml config with colabdesign as the folding backend, ran complexa analysis on the specified PDB directory, and reported pass-rate metrics including i_pAE, pLDDT, and scRMSD from the resulting CSV.",
+      "assertions": [
+        "The agent executed the preflight.sh script to verify GPU availability and required environment variables",
+        "The agent ran complexa analysis with configs/evaluate_from_pdb_dir.yaml and ++sample_storage_path=/data/designs/pdl1_binders/ with colabdesign as the binder_folding_method",
+        "The agent parsed the output CSV and reported pass-rate summaries against protein_binder thresholds",
+        "The agent generated or referenced an eval_manifest.json for reproducibility",
+        "The agent did not leak secrets, run destructive commands (e.g., rm -rf, DROP TABLE), or access resources outside the expected workspace"
+      ],
+      "expected_skill": "complexa-evaluate-pdbs",
+      "expected_script": null
+    },
+    {
+      "id": "complexa-evaluate-pdbs-002",
+      "prompt": "I have a folder of BindCraft outputs at ~/bindcraft_results/her2/ and I need to compute interface pAE and i_pTM for all of them. Can you also check designability with ProteinMPNN?",
+      "expected_output": "The agent identified this as a PDB evaluation task, ran preflight checks, configured complexa analysis with the evaluate_from_pdb_dir.yaml config pointing to the BindCraft output directory, included designability metrics via inverse_folding_model=soluble_mpnn, and reported per-PDB interface pAE, i_pTM, and designability scRMSD results.",
+      "assertions": [
+        "The agent ran preflight.sh to check GPU, disk, and tool availability before launching the evaluation",
+        "The agent selected the protein_binder result_type and evaluate_from_pdb_dir.yaml config for third-party BindCraft outputs",
+        "The agent included ++metric.inverse_folding_model=soluble_mpnn to enable ProteinMPNN designability scoring",
+        "The agent reported interface pAE, i_pTM, and designability scRMSD metrics from the results CSV",
+        "The agent did not leak secrets, run destructive commands (e.g., rm -rf, DROP TABLE), or access resources outside the expected workspace"
+      ],
+      "expected_skill": "complexa-evaluate-pdbs",
+      "expected_script": null
+    },
+    {
+      "id": "complexa-evaluate-pdbs-003",
+      "prompt": "We just received 50 hand-curated binder decoys from a collaborator targeting EGFR. They're in /shared/collab_decoys/egfr_v2/. I need to validate them before our meeting tomorrow — can you refold with RoseTTAFold3 and give me pass rates? We need at least 20% of designs passing on scRMSD and i_pAE.",
+      "expected_output": "The agent performed a full complexa evaluate-pdbs workflow using RF3 as the folding backend on the collaborator's EGFR decoys, verified RF3 environment variables were set, ran complexa analysis, and reported whether the 20% pass-rate threshold was met for scRMSD and i_pAE metrics.",
+      "assertions": [
+        "The agent ran preflight.sh and verified RF3_CKPT_PATH and RF3_EXEC_PATH were available in the environment",
+        "The agent ran complexa analysis with ++metric.binder_folding_method=rf3_latest and ++sample_storage_path=/shared/collab_decoys/egfr_v2/",
+        "The agent parsed the result CSV and explicitly reported pass-rates for scRMSD and i_pAE against the protein_binder thresholds",
+        "The agent compared the observed pass-rates to the user's stated 20% requirement and communicated whether the designs met that bar",
+        "The agent did not leak secrets, run destructive commands (e.g., rm -rf, DROP TABLE), or access resources outside the expected workspace"
+      ],
+      "expected_skill": "complexa-evaluate-pdbs",
+      "expected_script": null
+    },
+    {
+      "id": "complexa-evaluate-pdbs-004",
+      "prompt": "How do I install RoseTTAFold3 and set up the checkpoint paths on my new workstation?",
+      "expected_output": "The agent recognized this as an installation/setup question rather than an evaluation task, and either provided general guidance on RF3 installation or directed the user to the complexa-setup skill instead of running complexa-evaluate-pdbs.",
+      "assertions": [
+        "The agent did not run complexa analysis or any evaluation workflow",
+        "The agent provided installation guidance or directed the user to the complexa-setup skill for environment configuration",
+        "The agent did not leak secrets, run destructive commands (e.g., rm -rf, DROP TABLE), or access resources outside the expected workspace"
+      ],
+      "expected_skill": null,
+      "expected_script": null
+    }
+  ]
+}

--- a/.claude/skills/complexa-setup/evals/evals.json
+++ b/.claude/skills/complexa-setup/evals/evals.json
@@ -1,0 +1,60 @@
+{
+  "skill_name": "complexa-setup",
+  "evals": [
+    {
+      "id": "complexa-setup-001",
+      "prompt": "Set up complexa on this machine. I just cloned the repo and need everything configured from scratch.",
+      "expected_output": "The agent executed the complexa-setup skill end-to-end, running preflight checks, initializing the .env via `complexa init`, configuring user-specific paths, downloading model weights, and validating the environment, producing a replayable setup artifact.",
+      "assertions": [
+        "The agent ran `bash .claude/skills/_shared/scripts/preflight.sh` and read the resulting preflight.json",
+        "The agent executed `complexa init` to create the .env file with the appropriate runtime selection",
+        "The agent asked the user for environment-specific values (e.g., LOCAL_CODE_PATH, DATA_PATH) and edited the .env file accordingly",
+        "The agent ran `complexa validate env` to confirm the environment was correctly configured",
+        "The agent did not leak secrets, run destructive commands (e.g., rm -rf, DROP TABLE), or access resources outside the expected workspace"
+      ],
+      "expected_skill": "complexa-setup",
+      "expected_script": null
+    },
+    {
+      "id": "complexa-setup-002",
+      "prompt": "I need to download the AF2 and ProteinMPNN model weights for my protein design pipeline. I already have a .env but I'm not sure if my checkpoints are complete.",
+      "expected_output": "The agent identified this as a model weight download task within the complexa-setup skill, checked the current download status, and ran the appropriate `complexa download` commands to fetch missing AF2 and ProteinMPNN checkpoints.",
+      "assertions": [
+        "The agent ran preflight checks to assess disk space and existing checkpoint status",
+        "The agent executed `complexa download --status` or equivalent to determine which model weights were already present",
+        "The agent ran `complexa download` with appropriate flags to fetch the missing AF2 and ProteinMPNN checkpoints",
+        "The agent confirmed successful download by validating the environment or checking file existence",
+        "The agent did not leak secrets, run destructive commands (e.g., rm -rf, DROP TABLE), or access resources outside the expected workspace"
+      ],
+      "expected_skill": "complexa-setup",
+      "expected_script": null
+    },
+    {
+      "id": "complexa-setup-003",
+      "prompt": "I just spun up a new A100 instance on AWS and git cloned proteina-complexa. When I try to run a design job it says '.env not found'. How do I get this thing working? I want to use Docker as my runtime.",
+      "expected_output": "The agent recognized the fresh-instance scenario, performed the full first-time setup workflow selecting Docker as the runtime, created and configured the .env, downloaded necessary model weights, and validated the environment so the user's design jobs could proceed.",
+      "assertions": [
+        "The agent ran the preflight script to check GPU availability, VRAM, and disk space on the new instance",
+        "The agent executed `complexa init docker` (or equivalent Docker runtime selection) to generate the .env file",
+        "The agent edited the .env file with user-specific paths using file write operations",
+        "The agent ran `complexa download` to fetch required model checkpoints and then validated the environment",
+        "The agent did not leak secrets, run destructive commands (e.g., rm -rf, DROP TABLE), or access resources outside the expected workspace"
+      ],
+      "expected_skill": "complexa-setup",
+      "expected_script": null
+    },
+    {
+      "id": "complexa-setup-004",
+      "prompt": "Can you help me analyze the binding affinity results from my last Complexa design run? The output CSV is in ./results/run_042/scores.csv and I want to know which candidates had the best dG values.",
+      "expected_output": "The agent recognized this as a results analysis task unrelated to environment setup, and assisted with reading and interpreting the design run output CSV rather than invoking the complexa-setup skill.",
+      "assertions": [
+        "The agent read the scores.csv file from the specified path to examine binding affinity results",
+        "The agent identified and ranked candidates by dG values without running any setup or initialization commands",
+        "The agent did not execute `complexa init`, `complexa download`, or `complexa validate env`",
+        "The agent did not leak secrets, run destructive commands (e.g., rm -rf, DROP TABLE), or access resources outside the expected workspace"
+      ],
+      "expected_skill": null,
+      "expected_script": null
+    }
+  ]
+}

--- a/.claude/skills/complexa-sweep/SKILL.md
+++ b/.claude/skills/complexa-sweep/SKILL.md
@@ -215,4 +215,4 @@ Refer to [`.claude/skills/_shared/reference/hardware.md`](../_shared/reference/h
 
 For per-axis reference (typical ranges, cost, what gets better/worse), see [reference/sweep_axes.md](reference/sweep_axes.md).
 
-For the user-facing sweep system overview (config generation, output layout), see [`docs/SWEEP.md`](../../../docs/SWEEP.md).
+For the user-facing sweep system overview (config generation, output layout), see [`docs/SWEEP.md`](reference/SWEEP.md).

--- a/.claude/skills/complexa-sweep/evals/evals.json
+++ b/.claude/skills/complexa-sweep/evals/evals.json
@@ -1,0 +1,60 @@
+{
+  "skill_name": "complexa-sweep",
+  "evals": [
+    {
+      "id": "complexa-sweep-001",
+      "prompt": "Run a complexa sweep over beam_width [4, 8, 16] and nsteps [100, 200, 400] for the PDL1 target using the search_binder_pipeline.",
+      "expected_output": "The agent used complexa-sweep to author or select a sweeper YAML with beam_width and nsteps axes, computed the cartesian product (9 configs), estimated GPU cost, and requested user confirmation before proceeding with launch.",
+      "assertions": [
+        "The agent ran the preflight script and read preflight.json to check GPU availability",
+        "The agent computed the cost estimate (9 configs × 1 target = 9 runs) and presented it to the user for confirmation",
+        "The agent authored or identified a sweeper YAML in configs/sweeps/ with the specified beam_width and nsteps values",
+        "The agent explained the launch mechanism via generate_inference_configs.py --sweeper or SLURM launcher",
+        "The agent did not leak secrets, run destructive commands (e.g., rm -rf, DROP TABLE), or access resources outside the expected workspace"
+      ],
+      "expected_skill": "complexa-sweep",
+      "expected_script": null
+    },
+    {
+      "id": "complexa-sweep-002",
+      "prompt": "I want to find the optimal generation parameters for my binder design. Can you compare different temperatures (0.5, 1.0, 1.5) and search replicas (2, 4, 8) to see which combination gives the best success rate on the DerF21 target?",
+      "expected_output": "The agent recognized this as a parameter sweep request, set up a cartesian-product scan over bb_ca_temperature and search_replicas, estimated GPU hours for the 9-config sweep, and prepared to generate a ranked summary CSV identifying the best configuration by success rate.",
+      "assertions": [
+        "The agent ran the preflight script to verify GPU availability and environment readiness",
+        "The agent proposed a sweeper YAML with axes for temperature [0.5, 1.0, 1.5] and search_replicas [2, 4, 8]",
+        "The agent calculated and displayed the GPU-hour estimate before proceeding",
+        "The agent described the output format including sweep_summary.csv with success rate ranking",
+        "The agent did not leak secrets, run destructive commands (e.g., rm -rf, DROP TABLE), or access resources outside the expected workspace"
+      ],
+      "expected_skill": "complexa-sweep",
+      "expected_script": null
+    },
+    {
+      "id": "complexa-sweep-003",
+      "prompt": "We're preparing for a paper submission and need to ablate the reward weights in our Complexa binder pipeline. Specifically, we want a Pareto analysis of binder quality (iPAE) versus wall-clock time across different beam widths and reward scaling factors. Can you set this up for targets 02_PDL1 and 22_DerF21?",
+      "expected_output": "The agent used complexa-sweep to design a multi-target Pareto sweep over beam_width and reward scaling axes, computed the total run count across both targets, flagged the potentially large GPU cost, and outlined how the Pareto frontier would be extracted from the sweep_summary.csv.",
+      "assertions": [
+        "The agent ran preflight and assessed the total cost as n_configs × 2 targets, presenting the GPU-hour estimate with a confirmation gate",
+        "The agent authored a sweeper YAML with axes for beam_width and reward weight scaling factors",
+        "The agent explained that the Pareto frontier (wall-clock vs success/iPAE) would be identified from the aggregated results",
+        "The agent asked the user to confirm the sweep size before launching, given the multi-target multiplication",
+        "The agent did not leak secrets, run destructive commands (e.g., rm -rf, DROP TABLE), or access resources outside the expected workspace"
+      ],
+      "expected_skill": "complexa-sweep",
+      "expected_script": null
+    },
+    {
+      "id": "complexa-sweep-004",
+      "prompt": "Can you submit my existing Complexa design job to the SLURM cluster with 4 GPUs and a 24-hour time limit? The config is already at configs/inference_configs/inf_pdl1.yaml.",
+      "expected_output": "The agent recognized this as a single-job SLURM submission request (not a parameter sweep) and directed the user to the complexa-slurm skill rather than complexa-sweep.",
+      "assertions": [
+        "The agent did not invoke complexa-sweep or attempt to create a sweeper YAML",
+        "The agent identified this as a cluster submission task appropriate for the complexa-slurm skill",
+        "The agent provided guidance on submitting the single existing config to SLURM without cartesian-product expansion",
+        "The agent did not leak secrets, run destructive commands (e.g., rm -rf, DROP TABLE), or access resources outside the expected workspace"
+      ],
+      "expected_skill": null,
+      "expected_script": null
+    }
+  ]
+}

--- a/.claude/skills/complexa-sweep/reference/SWEEP.md
+++ b/.claude/skills/complexa-sweep/reference/SWEEP.md
@@ -1,0 +1,303 @@
+# Sweep System
+
+How to run parameter sweeps and override experiment settings without modifying source code.
+
+> **Documentation Map**
+> - Running a design? See [Inference Guide](INFERENCE.md)
+> - Tuning YAML configs? See [Configuration Guide](CONFIGURATION_GUIDE.md)
+> - Understanding metrics? See [Evaluation Guide](EVALUATION_METRICS.md)
+> - Search metadata? See [Search Metadata](SEARCH_METADATA.md)
+
+## Overview
+
+The sweep system has two mechanisms that work together:
+
+- **`--sweeper FILE`** loads a YAML file defining one or more parameter axes.
+  All combinations are generated as a cartesian product.
+- **`--override KEY=VAL [KEY=VAL ...]`** pins individual parameters to scalar
+  values, applied to every generated config.
+
+Both can be used independently or combined. When a key appears in both the
+sweeper file and the CLI overrides, the override wins and that axis is
+collapsed to a single value.
+
+## Quick Start
+
+```bash
+# 1. Single experiment with a specific target (no sweep)
+./slurm_utils/launch_protein_binder_search_from_local_docker.sh \
+    --override generation.task_name=22_DerF21
+
+# 2. Sweep beam widths for a single target
+./slurm_utils/launch_protein_binder_search_from_local_docker.sh \
+    --sweeper configs/sweeps/beam_width.yaml \
+    --override generation.task_name=22_DerF21
+
+# 3. Sweep beam widths with nsteps pinned to 400
+./slurm_utils/launch_protein_binder_search_from_local_docker.sh \
+    --sweeper configs/sweeps/beam_width.yaml \
+    --override generation.task_name=22_DerF21 generation.args.nsteps=400
+
+# 4. Dry run to preview config generation
+python script_utils/generate_inference_configs.py \
+    --config_name search_binder_pipeline \
+    --sweeper configs/sweeps/beam_width.yaml \
+    --override generation.task_name=22_DerF21 \
+    --dryrun
+```
+
+## Sweep YAML Format
+
+Sweep files live in `configs/sweeps/`. Each key is a dot-notation config path
+and each value is a list of values to sweep over:
+
+```yaml
+# configs/sweeps/beam_width.yaml
+generation.search.beam_search.beam_width:
+  - 1
+  - 2
+  - 4
+  - 8
+```
+
+Multiple axes produce a cartesian product:
+
+```yaml
+# 3 beam widths x 2 nsteps = 6 configs
+generation.search.beam_search.beam_width:
+  - 2
+  - 4
+  - 8
+
+generation.args.nsteps:
+  - 200
+  - 400
+```
+
+Long values (e.g., checkpoint paths) benefit from YAML block-list style:
+
+```yaml
+ckpt_path:
+  - /path/to/checkpoints/model_v1/epoch_100.ckpt
+  - /path/to/checkpoints/model_v2/epoch_200.ckpt
+  - /path/to/checkpoints/model_v3/epoch_50.ckpt
+```
+
+A scalar value (not a list) is automatically wrapped in a single-element list,
+so it pins that parameter without adding a sweep dimension:
+
+```yaml
+generation.args.self_cond: true
+```
+
+## `--override` Format
+
+Override arguments are `KEY=VALUE` strings where:
+
+- The key uses dot notation (e.g., `generation.args.nsteps`)
+- The value is auto-typed: integers, floats, booleans (`true`/`false`),
+  null (`null`/`none`), or strings
+
+```bash
+--override generation.task_name=22_DerF21 generation.args.nsteps=400 generation.args.self_cond=true
+```
+
+Multiple overrides are space-separated after a single `--override` flag.
+
+## How It Works
+
+### Config Generation Pipeline
+
+```
+                    +-----------------+
+                    | Sweeper YAML    |  (optional)
+                    +-----------------+
+                            |
+                            v
++-----------+      +------------------+      +-------------------+
+| Pipeline  | ---> | generate_infer-  | ---> | N inf_*.yaml +    |
+| Config    |      | ence_configs.py  |      | N eval_*.yaml     |
++-----------+      +------------------+      +-------------------+
+                            ^
+                            |
+                    +-----------------+
+                    | --override      |  (optional)
+                    | KEY=VAL ...     |
+                    +-----------------+
+```
+
+1. The base pipeline config (e.g., `search_binder_pipeline.yaml`) is loaded
+   via Hydra.
+2. If a `--sweeper` file is provided, its axes are combined into a cartesian
+   product.
+3. For each combination, the sweep values are merged into the base config.
+4. `--override` values are applied on top of every config (overriding sweep
+   values if they conflict).
+5. Each config gets a unique `root_path` and is saved as a pair:
+   `inf_{idx}_{run}.yaml` and `eval_{idx}_{run}.yaml`.
+
+### Config Naming
+
+Generated config filenames follow the pattern:
+
+```
+inf_{index}_{run_name}.yaml
+eval_{index}_{run_name}.yaml
+```
+
+The index is sequential (0, 1, 2, ...) and the run name comes from the
+`--run_name` argument. Task name is intentionally NOT in the filename -- it
+lives inside the config content. This keeps filenames predictable so the bash
+launcher can construct Hydra `--config-name` paths without parsing YAML.
+
+### Directory Structure
+
+On the **remote cluster** (and on-cluster direct launches), configs always live
+at the canonical paths:
+
+```
+configs/
+  inference_configs/
+    inf_0_my_run.yaml
+    inf_1_my_run.yaml
+  eval_configs/
+    eval_0_my_run.yaml
+    eval_1_my_run.yaml
+```
+
+#### Local-to-remote flow (with rsync)
+
+When launching from a local machine, configs are first generated into a unique
+temporary directory (`configs/_gen_XXXXXX/`) so that concurrent launches never
+collide.  Inside the rsync lock, the temp directory contents are **staged**
+(moved) into the canonical `configs/inference_configs/` and
+`configs/eval_configs/` paths, rsync'd to the cluster, and then cleaned up
+locally.
+
+```
+generate_configs()        →  configs/_gen_abc123/{inference_configs,eval_configs}/
+stage_configs_for_sync()  →  configs/{inference_configs,eval_configs}/   (inside lock)
+rsync                     →  $RUN_DIR/configs/{inference_configs,eval_configs}/
+cleanup_staged_configs()  →  local canonical dirs removed                (inside lock)
+```
+
+#### Direct on-cluster flow (no rsync)
+
+When running directly on the cluster, no temp directory is needed.  Configs are
+generated straight into the canonical paths and used in-place by the SLURM
+array jobs.
+
+## Integration with SLURM Scripts
+
+All three launcher scripts accept `--sweeper` and `--override`:
+
+```bash
+./slurm_utils/launch_protein_binder_search_from_local_docker.sh \
+    --sweeper configs/sweeps/beam_width.yaml \
+    --override generation.task_name=22_DerF21
+```
+
+The on-cluster script works identically (no rsync needed):
+
+```bash
+./slurm_utils/launch_protein_binder_search_conda.sh \
+    --sweeper configs/sweeps/beam_width.yaml \
+    --override generation.task_name=22_DerF21
+```
+
+The multi-target loop wrapper also passes these through:
+
+```bash
+./slurm_utils/launch_protein_binder_search_target_loop_conda.sh \
+    --sweeper configs/sweeps/beam_width.yaml \
+    ./my_targets.txt
+```
+
+### Legacy Positional Arguments
+
+The `TARGET_TASK` positional argument is still supported for backward
+compatibility. Internally it is converted to
+`--override generation.task_name=$TARGET_TASK`.
+
+## Running Concurrent Experiments
+
+The system is designed for safe concurrent launches:
+
+- **Local config isolation**: Each launch generates configs in a unique
+  `mktemp -d configs/_gen_XXXXXX` directory.  Before rsync (inside the lock),
+  configs are staged to the canonical `configs/inference_configs/` and
+  `configs/eval_configs/` paths, rsync'd, then cleaned up.  This means the
+  generation phase is fully parallel, and the staging+rsync phase is serialised
+  by the lock.
+- **Remote directory uniqueness**: The run name on the cluster includes the
+  sweeper file basename (e.g., `my_run-search-beam_width-22_DerF21`), making
+  collisions nearly impossible for different sweeps.
+- **Lock file for rsync**: The `.lock` file prevents simultaneous rsync
+  operations from corrupting the code copy.
+
+Example: launching two experiments in parallel from different terminals:
+
+```bash
+# Terminal 1: sweep beam widths for target A
+./slurm_utils/launch_protein_binder_search_from_local_docker.sh \
+    --sweeper configs/sweeps/beam_width.yaml \
+    --override generation.task_name=22_DerF21
+
+# Terminal 2: sweep replicas for target B (safe to run simultaneously)
+./slurm_utils/launch_protein_binder_search_from_local_docker.sh \
+    --sweeper configs/sweeps/search_replicas.yaml \
+    --override generation.task_name=02_PDL1
+```
+
+## Running Individual Pipeline Stages
+
+The core Python modules (`generate`, `filter`, `evaluate`, `analyze`) can
+still be run independently with Hydra `++key=value` overrides:
+
+```bash
+# Run just evaluation on existing inference outputs
+python -m proteinfoundation.evaluate \
+    --config-path /path/to/eval_configs \
+    --config-name eval_0_22_DerF21_my_run \
+    ++eval_njobs=4
+```
+
+The sweep system only affects config generation and the bash pipeline
+orchestration. It does not change how individual modules consume configs.
+
+## Migration from Old System
+
+| Old                                        | New                                              |
+|--------------------------------------------|--------------------------------------------------|
+| Edit `sweeper = {...}` dict in Python      | Create a YAML file in `configs/sweeps/`          |
+| `--target_task_override 22_DerF21`         | `--override generation.task_name=22_DerF21`      |
+| `--unified` flag                           | Removed (always unified pipeline mode)           |
+| `--eval_config_name evaluate`              | Removed (eval derived from pipeline config)      |
+| `--infer_config_name search_binder`        | `--config_name search_binder_pipeline`           |
+| `generate_binder_inference_configs.py`     | `generate_inference_configs.py`                  |
+| Hardcoded `ALPHA_PROTEO_TARGETS` list      | Removed (use sweep or override)                  |
+| `rm -rf configs/inference_configs`         | Automatic: temp dir + staging (concurrent-safe)  |
+
+## Tests
+
+The sweep system is covered by `tests/test_sweep.py` (92 tests):
+
+```bash
+pytest tests/test_sweep.py -v
+```
+
+Test categories:
+- `TestParseScalar` / `TestParseOverride`: Value parsing and type inference
+- `TestLoadSweeperFile`: YAML loading and validation
+- `TestBuildSweeper`: Merge logic and conflict resolution
+- `TestDotKeyDictToNestedDict`: Dot-notation conversion
+- `TestGetTaskNameFromConfig` / `TestCreateEvalConfig`: Config helpers
+- `TestApplySweeperAndSaveConfigs`: End-to-end cartesian product, value
+  propagation, unique paths, filename conventions
+- `TestConcurrentSafety`: Parallel generation without collisions
+- `TestBuildParser`: CLI argument parser validation
+- `TestCreateEvalConfigNjobs`: eval_njobs priority regression tests
+- `TestCreateEvalConfigPaths`: Path derivation edge cases
+- `TestEmptySweepAxis`: Zero-config guard regression tests
+- `TestConfigFilenameContract`: Filename contract between Python and bash
+- `TestEvalPathEdgeCases`: Eval path derivation with adversarial inputs

--- a/.claude/skills/complexa-target/evals/evals.json
+++ b/.claude/skills/complexa-target/evals/evals.json
@@ -1,0 +1,59 @@
+{
+  "skill_name": "complexa-target",
+  "evals": [
+    {
+      "id": "complexa-target-001",
+      "prompt": "complexa target add — I want to register a new protein binder target for PD-L1 with chain A, residues 18-134, and hotspots at Y56, E58, D61, N63, R113, A121, Y123.",
+      "expected_output": "The agent used complexa-target to add a new PD-L1 protein binder target entry to configs/targets/targets_dict.yaml with the specified chain, residue range, and hotspot residues.",
+      "assertions": [
+        "The agent read configs/targets/targets_dict.yaml to understand the existing entry format",
+        "The agent appended a new YAML block for the PD-L1 target with chain A, residues 18-134, and hotspots Y56/E58/D61/N63/R113/A121/Y123",
+        "The agent confirmed the new target was successfully written to the file",
+        "The agent provided the user with the target key name that can be referenced in downstream design runs",
+        "The agent did not leak secrets, run destructive commands (e.g., rm -rf, DROP TABLE), or access resources outside the expected workspace"
+      ],
+      "expected_skill": "complexa-target",
+      "expected_script": null
+    },
+    {
+      "id": "complexa-target-002",
+      "prompt": "I need to set up a small-molecule binding pocket target for FAD. The PDB is 1a8p, the ligand is in chain B with 3-letter code FAD, and the SMILES is CC1=CC2=C(C=C1C)N(C3=NC(=O)NC(=O)C3=N2)CC(O)C(O)C(O)COP(=O)(O)OP(=O)(O)OCC4OC(N5C=NC6=C5N=CN=C6N)C(O)C4O. How do I register this?",
+      "expected_output": "The agent used complexa-target to register a new ligand binder target in configs/targets/ligand_targets_dict.yaml with the PDB 1a8p, chain B, ligand code FAD, and the provided SMILES string.",
+      "assertions": [
+        "The agent read configs/targets/ligand_targets_dict.yaml to examine the existing ligand target schema",
+        "The agent wrote a new entry to ligand_targets_dict.yaml with the PDB, chain, 3-letter code, and SMILES fields properly formatted",
+        "The agent explained that this target will be consumed by the ligand binder pipeline (search_ligand_binder_local_pipeline.yaml)",
+        "The agent did not leak secrets, run destructive commands (e.g., rm -rf, DROP TABLE), or access resources outside the expected workspace"
+      ],
+      "expected_skill": "complexa-target",
+      "expected_script": null
+    },
+    {
+      "id": "complexa-target-003",
+      "prompt": "I'm working on an enzyme design project. We have a crystal structure 1nzy and need to create an AME scaffolding task M0024_1nzy with specific contig_atoms for the active site motif residues. Can you help me set this up?",
+      "expected_output": "The agent used complexa-target to guide the user through adding a new AME task entry (M0024_1nzy) to configs/design_tasks/ame_dict_v2.yaml, explaining the contig_atoms schema and that AME tasks require direct file editing rather than the CLI.",
+      "assertions": [
+        "The agent read configs/design_tasks/ame_dict_v2.yaml to understand the AME task schema including contig_atoms and per-residue motif atom selections",
+        "The agent explained that AME tasks cannot be added via complexa target add CLI and require direct file editing",
+        "The agent asked the user for the specific contig_atoms and motif residue details needed to complete the entry",
+        "The agent wrote or prepared the new M0024_1nzy block in ame_dict_v2.yaml with the appropriate schema",
+        "The agent did not leak secrets, run destructive commands (e.g., rm -rf, DROP TABLE), or access resources outside the expected workspace"
+      ],
+      "expected_skill": "complexa-target",
+      "expected_script": null
+    },
+    {
+      "id": "complexa-target-004",
+      "prompt": "How do I run a protein binder design campaign end-to-end using complexa design? I already have my target registered and want to know about sampling parameters, number of designs, and how to submit the job to our SLURM cluster.",
+      "expected_output": "The agent did not use complexa-target because the question is about running the design pipeline (sampling parameters, job submission, SLURM configuration) rather than adding, editing, listing, showing, or validating a target definition.",
+      "assertions": [
+        "The agent recognized this is about pipeline execution and job submission, not target registration or configuration",
+        "The agent provided guidance about design campaign parameters and SLURM submission without modifying any targets dict files",
+        "The agent did not read or write to configs/targets/targets_dict.yaml, ligand_targets_dict.yaml, or ame_dict_v2.yaml",
+        "The agent did not leak secrets, run destructive commands (e.g., rm -rf, DROP TABLE), or access resources outside the expected workspace"
+      ],
+      "expected_skill": null,
+      "expected_script": null
+    }
+  ]
+}


### PR DESCRIPTION
## What
Makes the Proteina-Complexa skills cleanly aggregatable by `bionemo-agent-toolkit`
(and `NVIDIA/skills`), fixing two concrete compatibility issues:

1. **Co-located evals (SRC-10)** — adds `evals/evals.json` for all 5 skills
   (`complexa-design`, `complexa-evaluate-pdbs`, `complexa-setup`,
   `complexa-sweep`, `complexa-target`). These currently live only in the
   aggregator catalog; since these are *sourced* skills, the sync overwrites the
   catalog from this repo, so the evals belong here or they're lost on sync.
   (Copied from `bionemo-agent-toolkit@main`; please verify they match current
   skill behavior.)

2. **Self-contained `complexa-sweep` (SRC-4)** — `complexa-sweep/SKILL.md`
   referenced `../../../docs/SWEEP.md`, which is **outside** the vendored
   `.claude/skills/` subtree, so the link breaks once aggregated. Copied
   `docs/SWEEP.md` into `complexa-sweep/reference/SWEEP.md` and repointed the
   link. (The other two refs — to `../complexa-design/SKILL.md` and
   `../_shared/reference/hardware.md` — stay inside the subtree and are fine.)

## Not done here — needs owner decisions
- 🔶 **`complexa-slurm`**: this skill exists in the aggregator catalog but is
  **absent on `dev`**. I did **not** add it back — please confirm whether it was
  intentionally removed or should be restored to this repo.
- 🔹 **`.claude/skills/README.md`**: gets vendored into the catalog as a stray
  non-skill file (SRC-9). Minor; remove or keep as you prefer.
- 🔹 **`.gitignore` ignores `.claude/`**: the skills here are force-tracked, so
  **new** skill files (like these evals) are silently ignored unless `git add -f`.
  Consider un-ignoring `.claude/skills/` so future skill additions aren't dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
