### PR TITLE
docs: add skill cards for the five complexa-* agent skills

### DIFF
--- a/.claude/skills/complexa-design/skill-card.md
+++ b/.claude/skills/complexa-design/skill-card.md
@@ -1,0 +1,80 @@
+## Description: <br>
+Drives the end-to-end Proteina-Complexa design pipeline — `complexa design <pipeline>` from target selection through manifest emission — for protein binder, ligand binder, and AME / motif-scaffolding tasks, and reports how many designs passed. <br>
+
+This skill is ready for commercial/non-commercial use. <br>
+
+## Owner
+NVIDIA <br>
+
+### License/Terms of Use: <br>
+This repository contains multiple components under different licenses; see [`LICENSE`](../../../LICENSE) and the `licenses/` directory. <br>
+
+## Use Case: <br>
+Protein designers and computational biologists running de novo binder design against a registered target — generating candidate binders with reward-guided flow matching, refolding them with an independent structure predictor (AF2 or RF3), and ranking by interface metrics (success rate, interface pAE, scRMSD, FoldSeek diversity). This is the scientific anchor of the `complexa-*` skill set. <br>
+
+### Requirements/Dependencies: <br>
+Requires API Key or External Credential: No <br>
+Credential Type(s): None <br>
+
+* `complexa` CLI installed (`pip install -e .`) <br>
+* `.env` populated (`complexa-setup`) and a target registered (`complexa-target`) <br>
+* 1× CUDA GPU with ≥40 GB VRAM (A100 / H100 / L40S) <br>
+* 24 CPUs, ~50 GB disk <br>
+* Folding backend weights: AF2 (ColabDesign) or RF3 <br>
+
+Do not include secrets in prompts/logs/output; use least-privilege credentials; rotate keys as appropriate. <br>
+
+### Deployment Geography for Use: <br>
+Global <br>
+
+## Known Risks and Mitigations: <br>
+Risk: Designed binders are computational predictions. Reported success rates, interface pAE, and scRMSD are in-silico metrics that correlate imperfectly with experimental binding; treating them as validated hits wastes wet-lab resources. <br>
+Mitigation: The pipeline refolds designs with a structure predictor independent of the generator and reports pass rates against explicit thresholds rather than a single score. All outputs require experimental validation. <br>
+
+Risk: A full design campaign is a long, GPU-intensive workload that a single agent instruction can start, consuming substantial GPU-hours or cloud spend. <br>
+Mitigation: The skill runs a pre-flight validation step before launching and emits a replayable manifest, so configuration errors surface before the expensive stage. <br>
+
+Risk: Incorrect target or hotspot configuration directs the entire campaign at the wrong surface, with the error invisible until results are inspected. <br>
+Mitigation: The skill validates the target as an explicit pipeline step and refuses to proceed on an invalid target. <br>
+
+Risk: Generation is stochastic — repeated runs with identical inputs produce different binders unless a seed is fixed, which can confound comparisons between configurations. <br>
+Mitigation: The emitted manifest records the run configuration for replay; use `complexa-sweep` for controlled comparisons across configurations. <br>
+
+Risk: The skill writes design outputs and can overwrite results from a previous campaign in the same directory. <br>
+Mitigation: Outputs are written under explicit per-run output paths. <br>
+
+## Reference(s): <br>
+- [Proteina-Complexa repository](https://github.com/NVIDIA-BioNeMo/Proteina-Complexa) <br>
+- La-Proteina — the flow-based generative model this work builds on <br>
+- [ColabDesign / AlphaFold2](https://github.com/sokrypton/ColabDesign) and RF3 — independent refolding backends <br>
+- [Foldseek](https://github.com/steineggerlab/foldseek) — structural diversity metric <br>
+- Related skills: `complexa-setup`, `complexa-target`, `complexa-evaluate-pdbs`, `complexa-sweep` <br>
+
+## Skill Output: <br>
+**Output Type(s):** [Files, Analysis] <br>
+**Output Format:** [PDB structures of designed binders; result CSV of per-design metrics; replayable JSON manifest; Markdown summary] <br>
+**Output Parameters:** [3D for atomic coordinates; 2D for the per-design metric table; 1D for campaign-level pass rates] <br>
+**Other Properties Related to Output:** [Outputs are computational predictions, not measurements. Confidence and interface metrics are model-reported and are not calibrated probabilities of experimental binding. Generation is stochastic unless seeded.] <br>
+
+## Evaluation Agents Used: <br>
+Target agents: `claude-code`, `codex`. NVSkills-Eval has not yet been run against this skill — see Evaluation Results. <br>
+
+## Evaluation Tasks: <br>
+Not yet present on this branch. A co-located `evals/evals.json` with 4 tasks — covering pipeline selection, pre-flight validation, design execution, and result collection with manifest emission — is introduced by [PR #57](https://github.com/NVIDIA-BioNeMo/Proteina-Complexa/pull/57) (branch `aggregator-compat`) and lands on `dev` when that merges. <br>
+
+## Evaluation Metrics Used: <br>
+Planned NVSkills-Eval dimensions: Security, Correctness, Discoverability, Effectiveness, Efficiency. <br>
+
+## Evaluation Results: <br>
+Pending. NVSkills-Eval has not been run for this skill; results and a `BENCHMARK.md` will be published when the evaluation pipeline runs. <br>
+
+## Skill Version(s): <br>
+5391310 (source: git SHA, committed 2026-07-16) <br>
+
+## Ethical Considerations: <br>
+NVIDIA believes Trustworthy AI is a shared responsibility and we have established policies and practices to enable development for a wide array of AI applications. When downloaded or used in accordance with our terms of service, developers should work with their internal team to ensure this skill meets requirements for the relevant industry and use case and addresses unforeseen product misuse. <br>
+
+This skill generates novel protein sequences and structures. Users are responsible for screening designed sequences before synthesis, and for using the skill consistent with applicable biosecurity norms, biosafety review processes, and export-control obligations. Designed binders are research hypotheses and must not be used for clinical decision-making, diagnosis, or treatment selection. <br>
+
+(For Release on NVIDIA Platforms Only) <br>
+Please report quality, risk, security vulnerabilities or NVIDIA AI Concerns [here](https://www.nvidia.com/en-us/support/submit-security-vulnerability/). <br>

--- a/.claude/skills/complexa-evaluate-pdbs/skill-card.md
+++ b/.claude/skills/complexa-evaluate-pdbs/skill-card.md
@@ -1,0 +1,75 @@
+## Description: <br>
+Evaluates an existing directory of PDB files with Proteina-Complexa — selecting the correct `evaluate_*.yaml` config and folding backend, running the `complexa analysis` evaluate-then-analyze chain, parsing the result CSV, reporting pass rates against `result_type` thresholds, and emitting a replayable `eval_manifest.json`. <br>
+
+This skill is ready for commercial/non-commercial use. <br>
+
+## Owner
+NVIDIA <br>
+
+### License/Terms of Use: <br>
+This repository contains multiple components under different licenses; see [`LICENSE`](../../../LICENSE) and the `licenses/` directory. <br>
+
+## Use Case: <br>
+Protein designers scoring binder candidates that already exist as structures — refolding designs, computing interface pAE, i_pLDDT, scRMSD, and motif RMSD, and assessing designability. Works on Proteina-Complexa output and equally on third-party outputs (BindCraft, AlphaProteo, RFdiffusion, hand-curated decoys), so it serves as a common yardstick across design methods. <br>
+
+### Requirements/Dependencies: <br>
+Requires API Key or External Credential: No <br>
+Credential Type(s): None <br>
+
+* `complexa` CLI installed (`pip install -e .`) <br>
+* CUDA GPU <br>
+* A folding backend: `AF2_DIR` (ColabDesign) or `RF3_CKPT_PATH` + `RF3_EXEC_PATH` (rf3_latest) <br>
+* ESMFold weights for monomer evaluation paths <br>
+* A directory of input PDB files <br>
+
+Do not include secrets in prompts/logs/output; use least-privilege credentials; rotate keys as appropriate. <br>
+
+### Deployment Geography for Use: <br>
+Global <br>
+
+## Known Risks and Mitigations: <br>
+Risk: Pass rates are only meaningful relative to the thresholds of the selected `result_type`; comparing numbers produced under different configs or folding backends is misleading. <br>
+Mitigation: The skill emits a replayable `eval_manifest.json` recording the config, backend, and thresholds used, so comparisons can be checked for like-for-like. <br>
+
+Risk: Evaluating designs with the same model family that generated them inflates apparent quality. <br>
+Mitigation: The skill supports independent folding backends (AF2/ColabDesign, RF3, ESMFold) and is documented for use as an independent check; users should choose a backend distinct from the generator. <br>
+
+Risk: Refolding a large PDB directory is GPU-intensive and can run far longer than a user expects from a single instruction. <br>
+Mitigation: The skill selects the appropriate config up front and reports the input set size before running. <br>
+
+Risk: Malformed or non-standard PDB inputs — particularly third-party outputs with unusual chain or numbering conventions — can be silently skipped or misparsed. <br>
+Mitigation: The skill parses the result CSV and reports counts, so a shortfall between inputs and scored designs is visible. <br>
+
+## Reference(s): <br>
+- [Proteina-Complexa repository](https://github.com/NVIDIA-BioNeMo/Proteina-Complexa) <br>
+- [ColabDesign / AlphaFold2](https://github.com/sokrypton/ColabDesign), RF3, and [ESMFold](https://github.com/facebookresearch/esm) — supported folding backends <br>
+- Related skills: `complexa-setup`, `complexa-design`, `complexa-sweep` <br>
+
+## Skill Output: <br>
+**Output Type(s):** [Analysis, Files] <br>
+**Output Format:** [Result CSV of per-design metrics; `eval_manifest.json`; Markdown pass-rate report] <br>
+**Output Parameters:** [2D — one row per evaluated design, columns for interface pAE, i_pLDDT, scRMSD, motif RMSD; 1D for aggregate pass rates] <br>
+**Other Properties Related to Output:** [Metrics are model-reported in-silico estimates, not measurements, and are not calibrated probabilities of experimental binding.] <br>
+
+## Evaluation Agents Used: <br>
+Target agents: `claude-code`, `codex`. NVSkills-Eval has not yet been run against this skill — see Evaluation Results. <br>
+
+## Evaluation Tasks: <br>
+Not yet present on this branch. A co-located `evals/evals.json` with 4 tasks — covering config selection, backend wiring, evaluation execution, and pass-rate reporting with manifest emission — is introduced by [PR #57](https://github.com/NVIDIA-BioNeMo/Proteina-Complexa/pull/57) (branch `aggregator-compat`) and lands on `dev` when that merges. <br>
+
+## Evaluation Metrics Used: <br>
+Planned NVSkills-Eval dimensions: Security, Correctness, Discoverability, Effectiveness, Efficiency. <br>
+
+## Evaluation Results: <br>
+Pending. NVSkills-Eval has not been run for this skill; results and a `BENCHMARK.md` will be published when the evaluation pipeline runs. <br>
+
+## Skill Version(s): <br>
+5391310 (source: git SHA, committed 2026-07-16) <br>
+
+## Ethical Considerations: <br>
+NVIDIA believes Trustworthy AI is a shared responsibility and we have established policies and practices to enable development for a wide array of AI applications. When downloaded or used in accordance with our terms of service, developers should work with their internal team to ensure this skill meets requirements for the relevant industry and use case and addresses unforeseen product misuse. <br>
+
+Evaluation results are computational hypotheses. A high in-silico pass rate is not evidence of experimental binding, and must not be used for clinical decision-making, diagnosis, or treatment selection. <br>
+
+(For Release on NVIDIA Platforms Only) <br>
+Please report quality, risk, security vulnerabilities or NVIDIA AI Concerns [here](https://www.nvidia.com/en-us/support/submit-security-vulnerability/). <br>

--- a/.claude/skills/complexa-setup/skill-card.md
+++ b/.claude/skills/complexa-setup/skill-card.md
@@ -1,0 +1,68 @@
+## Description: <br>
+Performs first-time setup for Proteina-Complexa — driving `complexa init`, `complexa download`, and `complexa validate env` end to end, editing required `.env` keys, selecting the UV or Docker runtime, and emitting a replayable setup artifact. <br>
+
+This skill is ready for commercial/non-commercial use. <br>
+
+## Owner
+NVIDIA <br>
+
+### License/Terms of Use: <br>
+This repository contains multiple components under different licenses; see [`LICENSE`](../../../LICENSE) and the `licenses/` directory. <br>
+
+## Use Case: <br>
+Protein designers and computational biologists making a fresh Proteina-Complexa checkout runnable — verifying GPU preflight, configuring `.env`, and installing model weights (Complexa, AF2, RF3, ProteinMPNN, LigandMPNN, ESM2, ESMFold). This is the first skill to run on a new clone; every other `complexa-*` skill depends on it. <br>
+
+### Requirements/Dependencies: <br>
+Requires API Key or External Credential: Optional <br>
+Credential Type(s): Credentials for model-weight sources, as required by the individual checkpoints being downloaded <br>
+
+* `complexa` CLI installed (`pip install -e .`) <br>
+* bash 4+ <br>
+* `nvidia-smi` optional at setup time; a CUDA GPU is required for the design and evaluation skills <br>
+* Substantial disk for model checkpoints <br>
+
+Do not include secrets in prompts/logs/output; use least-privilege credentials; rotate keys as appropriate. <br>
+
+### Deployment Geography for Use: <br>
+Global <br>
+
+## Known Risks and Mitigations: <br>
+Risk: The skill edits the user's `.env` file, which holds paths and may hold credentials; a mis-edit could break the environment or expose values in an agent transcript. <br>
+Mitigation: The skill edits only the required keys and reports what changed; `.env` is git-ignored in this repository and must never be committed. Users should treat agent transcripts as sensitive. <br>
+
+Risk: Model-weight downloads are large and fetch third-party checkpoints (AF2/ColabDesign, RF3, ESMFold, ProteinMPNN, LigandMPNN) whose licenses differ from this repository's. <br>
+Mitigation: `complexa download --status` reports what is present before fetching; users are responsible for reviewing and complying with each checkpoint's upstream license terms. <br>
+
+Risk: A partially completed setup produces confusing failures much later, inside long-running design jobs. <br>
+Mitigation: `complexa validate env` runs as an explicit final step so environment problems surface at setup time. <br>
+
+## Reference(s): <br>
+- [Proteina-Complexa repository](https://github.com/NVIDIA-BioNeMo/Proteina-Complexa) <br>
+- Related skills: `complexa-target`, `complexa-design`, `complexa-evaluate-pdbs`, `complexa-sweep` <br>
+
+## Skill Output: <br>
+**Output Type(s):** [Analysis, Files, Configuration instructions] <br>
+**Output Format:** [Markdown setup report; edited `.env`; downloaded checkpoint files; replayable setup artifact] <br>
+**Output Parameters:** [1D — per-check pass/fail status, resolved runtime, installed model inventory] <br>
+**Other Properties Related to Output:** [Side effects: writes `.env`, downloads model weights to disk] <br>
+
+## Evaluation Agents Used: <br>
+Target agents: `claude-code`, `codex`. NVSkills-Eval has not yet been run against this skill — see Evaluation Results. <br>
+
+## Evaluation Tasks: <br>
+Not yet present on this branch. A co-located `evals/evals.json` with 4 tasks — covering init, weight download and status reporting, `.env` configuration, and environment validation — is introduced by [PR #57](https://github.com/NVIDIA-BioNeMo/Proteina-Complexa/pull/57) (branch `aggregator-compat`) and lands on `dev` when that merges. <br>
+
+## Evaluation Metrics Used: <br>
+Planned NVSkills-Eval dimensions: Security, Correctness, Discoverability, Effectiveness, Efficiency. <br>
+
+## Evaluation Results: <br>
+Pending. NVSkills-Eval has not been run for this skill; results and a `BENCHMARK.md` will be published when the evaluation pipeline runs. <br>
+
+## Skill Version(s): <br>
+5391310 (source: git SHA, committed 2026-07-16) <br>
+
+## Ethical Considerations: <br>
+NVIDIA believes Trustworthy AI is a shared responsibility and we have established policies and practices to enable development for a wide array of AI applications. When downloaded or used in accordance with our terms of service, developers should work with their internal team to ensure this skill meets requirements for the relevant industry and use case and addresses unforeseen product misuse. <br>
+
+(For Release on NVIDIA Platforms Only) <br>
+Please report quality, risk, security vulnerabilities or NVIDIA AI Concerns [here](https://www.nvidia.com/en-us/support/submit-security-vulnerability/). <br>

--- a/.claude/skills/complexa-sweep/skill-card.md
+++ b/.claude/skills/complexa-sweep/skill-card.md
@@ -1,0 +1,75 @@
+## Description: <br>
+Runs parameter sweeps over a Proteina-Complexa design pipeline — authoring sweeper YAML, expanding cartesian-product configurations, and ranking per-configuration results for hyperparameter scans and Pareto search over generation, reward, and evaluation knobs. <br>
+
+This skill is ready for commercial/non-commercial use. <br>
+
+## Owner
+NVIDIA <br>
+
+### License/Terms of Use: <br>
+This repository contains multiple components under different licenses; see [`LICENSE`](../../../LICENSE) and the `licenses/` directory. <br>
+
+## Use Case: <br>
+Protein designers and method developers tuning a design pipeline — scanning beam width, step count, temperature, or reward weights; ablating reward components; or trading binder quality against wall-clock. This is the only skill that owns sweeper YAML authoring and per-configuration result ranking. <br>
+
+### Requirements/Dependencies: <br>
+Requires API Key or External Credential: No <br>
+Credential Type(s): None <br>
+
+* `complexa` CLI installed (`pip install -e .`) <br>
+* `complexa-setup` completed and a target registered (`complexa-target`) <br>
+* CUDA GPU meeting the `complexa-design` requirements, for each configuration in the sweep <br>
+* Disk and GPU-hours proportional to the size of the cartesian product <br>
+
+Do not include secrets in prompts/logs/output; use least-privilege credentials; rotate keys as appropriate. <br>
+
+### Deployment Geography for Use: <br>
+Global <br>
+
+## Known Risks and Mitigations: <br>
+Risk: This is the highest-cost skill in the family. A cartesian product expands multiplicatively, so a sweep specified in one short instruction can launch dozens of full design campaigns and consume very large amounts of GPU time or cloud spend. <br>
+Mitigation: The skill expands and reports the configuration list before execution, so the user sees the run count before committing. Users should start with a small grid and confirm cost before widening. <br>
+
+Risk: Ranking configurations on a stochastic pipeline can select a configuration that merely got a lucky seed rather than one that is genuinely better. <br>
+Mitigation: Results are reported per configuration rather than as a single winner, so users can judge whether differences exceed run-to-run variance. Seeds should be fixed for like-for-like comparison. <br>
+
+Risk: Sweeping on a small or unrepresentative target set overfits hyperparameters to that target, and the choice may not transfer. <br>
+Mitigation: Per-configuration results are retained so users can re-examine the ranking against a held-out target. <br>
+
+Risk: A large sweep writes many output directories and can exhaust disk mid-run, losing partially completed configurations. <br>
+Mitigation: Outputs are written under explicit per-configuration paths; users should size storage against the expanded run count. <br>
+
+## Reference(s): <br>
+- [Proteina-Complexa repository](https://github.com/NVIDIA-BioNeMo/Proteina-Complexa) <br>
+- `reference/sweep_axes.md` in this skill directory — the sweepable parameter axes <br>
+- `configs/sweeps/` — example sweep definitions <br>
+- Related skills: `complexa-design`, `complexa-target`, `complexa-evaluate-pdbs` <br>
+
+## Skill Output: <br>
+**Output Type(s):** [Files, Analysis] <br>
+**Output Format:** [Sweeper YAML; per-configuration design outputs and result CSVs; Markdown ranking table] <br>
+**Output Parameters:** [2D — one row per configuration, columns for the swept parameters and resulting metrics] <br>
+**Other Properties Related to Output:** [Rankings reflect in-silico metrics on a stochastic pipeline; differences within run-to-run variance should not be treated as meaningful.] <br>
+
+## Evaluation Agents Used: <br>
+Target agents: `claude-code`, `codex`. NVSkills-Eval has not yet been run against this skill — see Evaluation Results. <br>
+
+## Evaluation Tasks: <br>
+Not yet present on this branch. A co-located `evals/evals.json` with 4 tasks — covering sweeper YAML authoring, cartesian-product expansion, sweep execution, and per-configuration ranking — is introduced by [PR #57](https://github.com/NVIDIA-BioNeMo/Proteina-Complexa/pull/57) (branch `aggregator-compat`) and lands on `dev` when that merges. <br>
+
+## Evaluation Metrics Used: <br>
+Planned NVSkills-Eval dimensions: Security, Correctness, Discoverability, Effectiveness, Efficiency. <br>
+
+## Evaluation Results: <br>
+Pending. NVSkills-Eval has not been run for this skill; results and a `BENCHMARK.md` will be published when the evaluation pipeline runs. <br>
+
+## Skill Version(s): <br>
+5391310 (source: git SHA, committed 2026-07-16) <br>
+
+## Ethical Considerations: <br>
+NVIDIA believes Trustworthy AI is a shared responsibility and we have established policies and practices to enable development for a wide array of AI applications. When downloaded or used in accordance with our terms of service, developers should work with their internal team to ensure this skill meets requirements for the relevant industry and use case and addresses unforeseen product misuse. <br>
+
+Sweeps generate novel protein sequences and structures at scale. Users are responsible for screening designed sequences before synthesis, and for using the skill consistent with applicable biosecurity norms, biosafety review processes, and export-control obligations. <br>
+
+(For Release on NVIDIA Platforms Only) <br>
+Please report quality, risk, security vulnerabilities or NVIDIA AI Concerns [here](https://www.nvidia.com/en-us/support/submit-security-vulnerability/). <br>

--- a/.claude/skills/complexa-target/skill-card.md
+++ b/.claude/skills/complexa-target/skill-card.md
@@ -1,0 +1,70 @@
+## Description: <br>
+Adds, registers, edits, lists, shows, and validates Proteina-Complexa design targets — protein binder, ligand binder, and AME / enzyme-scaffolding — and is the only skill that writes the three target dictionary files. <br>
+
+This skill is ready for commercial/non-commercial use. <br>
+
+## Owner
+NVIDIA <br>
+
+### License/Terms of Use: <br>
+This repository contains multiple components under different licenses; see [`LICENSE`](../../../LICENSE) and the `licenses/` directory. <br>
+
+## Use Case: <br>
+Protein designers defining what to design against — registering a target structure, chain specification, hotspot residues, and binder length range before running `complexa-design`. Also covers `complexa validate target` and questions about chain-spec syntax and where hotspots live. <br>
+
+### Requirements/Dependencies: <br>
+Requires API Key or External Credential: No <br>
+Credential Type(s): None <br>
+
+* `complexa` CLI installed (`pip install -e .`) <br>
+* `complexa-setup` completed <br>
+* A target structure (PDB/mmCIF) or SMILES for ligand-binder targets <br>
+
+Do not include secrets in prompts/logs/output; use least-privilege credentials; rotate keys as appropriate. <br>
+
+### Deployment Geography for Use: <br>
+Global <br>
+
+## Known Risks and Mitigations: <br>
+Risk: This skill has exclusive write access to `configs/targets/{,ligand_}targets_dict.yaml` and `configs/design_tasks/ame_dict_v2.yaml`; a malformed edit could corrupt target definitions shared across a team's design runs. <br>
+Mitigation: `complexa validate target` runs as an explicit validation path, and the skill is the single documented owner of those files so edits are not made ad hoc from multiple places. <br>
+
+Risk: Incorrect hotspot residue numbering — a common failure when structure numbering differs from sequence numbering — silently redirects design to the wrong surface, wasting an entire downstream design campaign. <br>
+Mitigation: The skill validates targets before use and supports structure-confirmed hotspot specification rather than accepting bare residue indices without checking. <br>
+
+Risk: Target definitions may be derived from third-party structures (e.g. RCSB PDB entries) whose terms of use apply to downstream work. <br>
+Mitigation: Users are responsible for confirming the provenance and licensing of any structure they register. <br>
+
+## Reference(s): <br>
+- [Proteina-Complexa repository](https://github.com/NVIDIA-BioNeMo/Proteina-Complexa) <br>
+- [RCSB Protein Data Bank](https://www.rcsb.org/) — common source of target structures <br>
+- Related skills: `complexa-setup`, `complexa-design`, `complexa-sweep` <br>
+
+## Skill Output: <br>
+**Output Type(s):** [Files, Analysis] <br>
+**Output Format:** [YAML target dictionary entries; Markdown summary of registered targets] <br>
+**Output Parameters:** [1D — target identifier, chain spec, hotspot residues, binder length range] <br>
+**Other Properties Related to Output:** [Side effect: writes to the repository's target dictionary configuration files] <br>
+
+## Evaluation Agents Used: <br>
+Target agents: `claude-code`, `codex`. NVSkills-Eval has not yet been run against this skill — see Evaluation Results. <br>
+
+## Evaluation Tasks: <br>
+Not yet present on this branch. A co-located `evals/evals.json` with 4 tasks — covering target registration, listing/showing, chain and hotspot specification, and validation — is introduced by [PR #57](https://github.com/NVIDIA-BioNeMo/Proteina-Complexa/pull/57) (branch `aggregator-compat`) and lands on `dev` when that merges. <br>
+
+## Evaluation Metrics Used: <br>
+Planned NVSkills-Eval dimensions: Security, Correctness, Discoverability, Effectiveness, Efficiency. <br>
+
+## Evaluation Results: <br>
+Pending. NVSkills-Eval has not been run for this skill; results and a `BENCHMARK.md` will be published when the evaluation pipeline runs. <br>
+
+## Skill Version(s): <br>
+5391310 (source: git SHA, committed 2026-07-16) <br>
+
+## Ethical Considerations: <br>
+NVIDIA believes Trustworthy AI is a shared responsibility and we have established policies and practices to enable development for a wide array of AI applications. When downloaded or used in accordance with our terms of service, developers should work with their internal team to ensure this skill meets requirements for the relevant industry and use case and addresses unforeseen product misuse. <br>
+
+Target selection determines what a downstream design campaign is aimed at. Users are responsible for ensuring their design targets are consistent with applicable biosecurity norms and export-control obligations. <br>
+
+(For Release on NVIDIA Platforms Only) <br>
+Please report quality, risk, security vulnerabilities or NVIDIA AI Concerns [here](https://www.nvidia.com/en-us/support/submit-security-vulnerability/). <br>

--- a/.gitignore
+++ b/.gitignore
@@ -92,7 +92,14 @@ tests/test_eval_generated/
 .rsync_lock/
 
 .pytest_tmp/
-.claude/
+# Ignore .claude/ contents EXCEPT the published agent skills. The skills under
+# .claude/skills/ are tracked and are vendored downstream by the NVIDIA/skills
+# and bionemo-agent-toolkit catalogs. A bare `.claude/` excludes the directory
+# itself, so git never descends into it and a `!` negation cannot re-include
+# anything below it — which silently drops every NEW file added to a skill dir
+# (cards, evals, references) unless the author remembers `git add -f`.
+.claude/*
+!.claude/skills/
 .dotnet/
 .gitconfig
 .gnupg/


### PR DESCRIPTION
Adds a `skill-card.md` alongside each of the five `complexa-*` skills, following the NVIDIA skill card format used across the [NVIDIA/skills](https://github.com/NVIDIA/skills) catalog (326/326 skills there carry one).

## Why

The NVIDIA/skills sync workflow **drops any skill missing `skill-card.md`, `skill.oms.sig`, or an eval dataset** — the enforcement step removes the skill dir before the PR is created, so non-compliant skills never merge into the catalog. The same requirement is tracked as `SRC-11` in `bionemo-agent-toolkit`'s CONTRIBUTING.

State of this repo (`dev`) against those three artifacts:

| Artifact | Status |
|---|---|
| eval dataset | **not on `dev`** — arrives with #57 (`aggregator-compat`) |
| `skill-card.md` | **this PR** |
| `skill.oms.sig` | outstanding — needs `nvskills-ci` wired here |

The cards state the eval gap explicitly rather than claiming coverage that isn't on this branch. Once #57 merges, those lines should be updated to point at the landed `evals/evals.json`.

## What's in the cards

Per skill: description, owner, license, use case, requirements (complexa CLI, `.env`, GPU class and VRAM, folding-backend weights), risks and mitigations, references, output types, evaluation, and ethical considerations.

Risk sections are specific to each skill — in-silico metrics not predicting experimental binding (`complexa-design`), evaluating designs with the same model family that generated them (`complexa-evaluate-pdbs`), multiplicative GPU cost from cartesian-product expansion (`complexa-sweep`), hotspot residue-numbering errors silently redirecting a whole campaign (`complexa-target`), and third-party checkpoint licensing (`complexa-setup`).

`complexa-design` and `complexa-sweep` carry explicit biosecurity language, since those skills generate novel protein sequences at scale: users are responsible for screening designed sequences before synthesis and for compliance with biosafety review and export-control obligations.

**Evaluation results are marked pending, not fabricated.** NVSkills-Eval has not been run against these skills.

## Second commit: a `.gitignore` fix worth looking at

`.gitignore:95` ignores `.claude/` wholesale, but the skills under `.claude/skills/` are tracked and are vendored downstream. Because a bare `.claude/` excludes the *directory*, git never descends into it and **no `!` negation can re-include anything below it** — so every new file added to a skill dir is silently ignored unless the author remembers `git add -f`. I hit this writing these cards.

That means an `evals/` dir or a reference file added to a Complexa skill can be quietly lost. The fix switches to `.claude/*` plus `!.claude/skills/`. Verified both directions: a new file under `.claude/skills/` is no longer ignored, and other `.claude/` content still is.

It's a separate commit — drop it if the wholesale ignore is deliberate.

## Context

`bionemo-agent-toolkit` vendors these five skills via `components.d/proteina-complexa.yml` and rsyncs with `--delete`, so a card committed there is wiped on the next nightly sync. This repo is the source of truth. The catalog carries an interim copy of these same cards in a `compliance.d/` overlay, which is retired automatically once this merges.

Targeting `dev` rather than `aggregator-compat` since that branch is deleted when #57 merges.

Please correct anything I got wrong about the pipelines or their risks — I wrote these from the SKILL.md files and repo layout, not from running the design pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
